### PR TITLE
Updated to kernel.dart processorToArchitecure map

### DIFF
--- a/lib/src/platform/kernel.dart
+++ b/lib/src/platform/kernel.dart
@@ -180,6 +180,8 @@ final processorToArchitecure = <String, ProcessorArchitecture>{
 // 'alpha', ProcessorArchitecture.alpah,
 // 'arc'
   'arm': ProcessorArchitecture.arm,
+  // Returned by Apple Silicon M2 when running uname -m
+  'arm64': ProcessorArchitecture.arm64,
   'aarch64_be': ProcessorArchitecture.arm64,
   'aarch64': ProcessorArchitecture.arm64,
   'armv7l': ProcessorArchitecture.arm,


### PR DESCRIPTION
On Apple Silicon (M2 Specifically) when calling uname -m the returned result is 'arm64'
<img width="577" alt="Screen Shot 2023-02-08 at 12 32 54 PM" src="https://user-images.githubusercontent.com/102485237/217607465-40c586df-3299-405f-b6b6-ecab8c3d911d.png">
