### PR TITLE
Add getAvailablePhysicalMemory() (Memory that is available for use)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,141 @@ doc/api/
 *.js.map.failed_tracker
 .failed_tracker
 .history
+
+
+# Do not remove or rename entries in this file, only add new ones
+# See https://github.com/flutter/flutter/issues/128635 for more context.
+
+# Miscellaneous
+*.class
+*.lock
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Visual Studio Code related
+.classpath
+.project
+.settings/
+.vscode/*
+
+# Flutter repo-specific
+/bin/cache/
+/bin/internal/bootstrap.bat
+/bin/internal/bootstrap.sh
+/bin/mingit/
+/dev/benchmarks/mega_gallery/
+/dev/bots/.recipe_deps
+/dev/bots/android_tools/
+/dev/devicelab/ABresults*.json
+/dev/docs/doc/
+/dev/docs/api_docs.zip
+/dev/docs/flutter.docs.zip
+/dev/docs/lib/
+/dev/docs/pubspec.yaml
+/dev/integration_tests/**/xcuserdata
+/dev/integration_tests/**/Pods
+/packages/flutter/coverage/
+version
+analysis_benchmark.json
+
+# packages file containing multi-root paths
+.packages.generated
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.flutter-plugins
+.flutter-plugins-dependencies
+**/generated_plugin_registrant.dart
+.pub-preload-cache/
+.pub-cache/
+.pub/
+flutter_*.png
+linked_*.ds
+unlinked.ds
+unlinked_spec.ds
+
+# Android related
+**/android/**/gradle-wrapper.jar
+.gradle/
+**/android/captures/
+**/android/gradlew
+**/android/gradlew.bat
+**/android/local.properties
+**/android/**/GeneratedPluginRegistrant.java
+**/android/key.properties
+*.jks
+
+# iOS/XCode related
+**/ios/**/*.mode1v3
+**/ios/**/*.mode2v3
+**/ios/**/*.moved-aside
+**/ios/**/*.pbxuser
+**/ios/**/*.perspectivev3
+**/ios/**/*sync/
+**/ios/**/.sconsign.dblite
+**/ios/**/.tags*
+**/ios/**/.vagrant/
+**/ios/**/DerivedData/
+**/ios/**/Icon?
+**/ios/**/Pods/
+**/ios/**/.symlinks/
+**/ios/**/profile
+**/ios/**/xcuserdata
+**/ios/.generated/
+**/ios/Flutter/.last_build_id
+**/ios/Flutter/App.framework
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+**/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/ephemeral
+**/ios/Flutter/app.flx
+**/ios/Flutter/app.zip
+**/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
+**/ios/ServiceDefinitions.json
+**/ios/Runner/GeneratedPluginRegistrant.*
+
+# macOS
+**/Flutter/ephemeral/
+**/Pods/
+**/macos/Flutter/GeneratedPluginRegistrant.swift
+**/macos/Flutter/ephemeral
+**/xcuserdata/
+
+# Windows
+**/windows/flutter/ephemeral/
+**/windows/flutter/generated_plugin_registrant.cc
+**/windows/flutter/generated_plugin_registrant.h
+**/windows/flutter/generated_plugins.cmake
+
+# Linux
+**/linux/flutter/ephemeral/
+**/linux/flutter/generated_plugin_registrant.cc
+**/linux/flutter/generated_plugin_registrant.h
+**/linux/flutter/generated_plugins.cmake
+
+# Coverage
+coverage/
+
+# Symbols
+app.*.symbols
+
+# Exceptions to above rules.
+!**/ios/**/default.mode1v3
+!**/ios/**/default.mode2v3
+!**/ios/**/default.pbxuser
+!**/ios/**/default.perspectivev3
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+!/dev/ci/**/Gemfile.lock
+!.vscode/settings.json

--- a/lib/src/platform/memory.dart
+++ b/lib/src/platform/memory.dart
@@ -28,6 +28,31 @@ int getFreePhysicalMemory() {
   }
 }
 
+int getAvailablePhysicalMemory() {
+  switch (Platform.operatingSystem) {
+    case 'android':
+    case 'linux':
+      final data = (fluent(exec('cat', ['/proc/meminfo']))
+        ..trim()
+        ..stringToMap(':'))
+          .mapValue;
+      final value = (fluent(data['MemAvailable'])
+        ..split(' ')
+        ..elementAt(0)
+        ..parseInt())
+          .intValue;
+      return value * 1024;
+    case 'macos':
+      return getFreeVirtualMemory();
+    case 'windows':
+      final data = wmicGetValueAsMap('OS', ['FreePhysicalMemory'])!;
+      final value = (fluent(data['FreePhysicalMemory'])..parseInt()).intValue;
+      return value * 1024;
+    default:
+      notSupportedError();
+  }
+}
+
 int getFreeVirtualMemory() {
   switch (Platform.operatingSystem) {
     case 'android':

--- a/lib/src/system_info.dart
+++ b/lib/src/system_info.dart
@@ -87,9 +87,22 @@ abstract class SysInfo {
 
   /// Returns the amount of free physical memory in bytes.
   ///
+  /// This is the amount of physical memory that is unused (or empty).
+  /// This is different from available memory, often lesser
+  ///
   ///     print(SysInfo.getFreePhysicalMemory());
   ///     => 3755331584
   static int getFreePhysicalMemory() => pm.getFreePhysicalMemory();
+
+
+  /// Returns the amount of available physical memory in bytes.
+  ///
+  /// This is the amount of physical memory that can be used by the system.
+  /// Most "diagnostic apps" show this as the "free memory"
+  ///
+  ///    print(SysInfo.getAvailablePhysicalMemory());
+  ///    => 3755331584
+  static int getAvailablePhysicalMemory() => pm.getAvailablePhysicalMemory();
 
   /// Returns the amount of free virtual memory in bytes.
   ///


### PR DESCRIPTION
Addresses #4, #8 
This is only for Android and Linux. On other platforms, `getFreePhysicalMemory()` is returned

Details
  - This method returns the amount of usable physical memory (RAM) in bytes, which can be reclaimed for use by the system.
  - This change addresses a semantic issue with the existing `getFreePhysicalMemory()` method, which reports unused memory - memory that isn't occupied but might not be available for allocation.
  - On Android and Linux, `getAvailablePhysicalMemory()` now accurately reflects the "available memory" typically shown in device settings and diagnostic apps, aligning with how most tools report memory that can be utilized.

Additional changes:
I have also added a standard .gitignore

Notes for maintainer
- With the new additions in .gitignore,  pub.dev will ask warn you about `.vscode/`  and `version/` directories being checked into git. There's 3 solutions
  1. Remove those from git (ideal)
  2. Add entries to .pubignore
  3. Remove entries from .gitignore
- On my fork, I have also written a more comprehensive readme, updated examples, compatibility info. I did not include it because it's not relevant to this issue