### PR TITLE
Add Storage Information

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -30,6 +30,10 @@ void main() {
       ': ${SysInfo.getFreeVirtualMemory() ~/ megaByte} MB');
   print('Virtual memory size     '
       ': ${SysInfo.getVirtualMemorySize() ~/ megaByte} MB');
+  print('Total storage           '
+      ': ${SysInfo.getTotalStorage() ~/ megaByte} MB');
+  print('Free storage            '
+      ': ${SysInfo.getFreeStorage() ~/ megaByte} MB');
 }
 
 const int megaByte = 1024 * 1024;

--- a/lib/src/platform/storage.dart
+++ b/lib/src/platform/storage.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import '../fluent.dart';
+import '../utils.dart';
+
+int getTotalStorage() {
+  switch (Platform.operatingSystem) {
+    case 'android':
+    case 'linux':
+      final mountPoint = Platform.operatingSystem == 'android' ? '/data' : '/';
+      final data = statFsGetValueAsMap(mountPoint, ['S', 'b'])!;
+      final blockSize = (fluent(data['S'])..parseInt()).intValue;
+      final blocksTotal = (fluent(data['b'])..parseInt()).intValue;
+      return blockSize * blocksTotal;
+    case 'windows':
+      final data = wmicGetValueAsMap('logicaldisk', ['Size'])!;
+      return (fluent(data['Size'])..parseInt()).intValue;
+    default:
+      notSupportedError();
+  }
+}
+
+int getFreeStorage() {
+  switch (Platform.operatingSystem) {
+    case 'android':
+    case 'linux':
+      final mountPoint = Platform.operatingSystem == 'android' ? '/data' : '/';
+      final data = statFsGetValueAsMap(mountPoint, ['S', 'a'])!;
+      final blockSize = (fluent(data['S'])..parseInt()).intValue;
+      final blocksFree = (fluent(data['a'])..parseInt()).intValue;
+      return blockSize * blocksFree;
+    case 'windows':
+      final data = wmicGetValueAsMap('logicaldisk', ['FreeSpace'])!;
+      return (fluent(data['FreeSpace'])..parseInt()).intValue;
+    default:
+      notSupportedError();
+  }
+}

--- a/lib/src/system_info.dart
+++ b/lib/src/system_info.dart
@@ -3,6 +3,7 @@ import 'platform/cpu.dart';
 import 'platform/kernel.dart';
 import 'platform/memory.dart' as pm;
 import 'platform/operating_system.dart';
+import 'platform/storage.dart' as stg;
 import 'platform/user.dart';
 import 'platform/userspace.dart';
 import 'processor_architecture.dart';
@@ -94,7 +95,6 @@ abstract class SysInfo {
   ///     => 3755331584
   static int getFreePhysicalMemory() => pm.getFreePhysicalMemory();
 
-
   /// Returns the amount of available physical memory in bytes.
   ///
   /// This is the amount of physical memory that can be used by the system.
@@ -127,4 +127,16 @@ abstract class SysInfo {
   ///     print(SysInfo.getVirtualMemorySize());
   ///     => 123456
   static int getVirtualMemorySize() => pm.getVirtualMemorySize();
+
+  /// Returns the total storage in bytes.
+  ///
+  ///    print(SysInfo.getTotalStorage());
+  ///    => 510745636864
+  static int getTotalStorage() => stg.getTotalStorage();
+
+  /// Returns the free storage in bytes.
+  ///
+  ///   print(SysInfo.getFreeStorage());
+  ///   => 255868657664
+  static int getFreeStorage() => stg.getFreeStorage();
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -120,6 +120,20 @@ Map<String, String>? wmicGetValueAsMap(String section, List<String> fields,
       .mapValue as Map<String, String>?;
 }
 
+String? _statFsGetValue(String mountPoint, List<String> fields) {
+  final format = fields.map((f) => '$f=%$f').join('\n');
+  return exec('stat', ['-f', '-c', format, mountPoint]);
+}
+
+Map<String, String>? statFsGetValueAsMap(
+    String mountPoint, List<String> fields) {
+  final string = _statFsGetValue(mountPoint, fields);
+  return (fluent(string)
+        ..stringToList()
+        ..listToMap('='))
+      .mapValue as Map<String, String>?;
+}
+
 Never notSupportedError() {
   throw UnsupportedError('Unsupported operating system.');
 }


### PR DESCRIPTION
@bsutton 

## 📌 Description

This PR adds the **storage information** feature to the library.
New functions have been implemented to display total and available system storage.

---

## 🔨 Changes

* **utils**: created a function to obtain `StatFs` values and convert to map.
* **storage**: added functions to get total and available storage.
* **example**: updated the example to include storage information output.

---

## 📷 Evidence (screenshots)
**[Android]**
<img width="1080" height="553" alt="lib_android" src="https://github.com/user-attachments/assets/e3a26672-cf07-4c33-bc72-66c64c321a71" />

**[Windows]**
<img width="1301" height="850" alt="lib_windows" src="https://github.com/user-attachments/assets/4c9e931e-b96a-4b48-8bc5-59d1cadd93cf" />

**[Linux]**
<img width="829" height="605" alt="lib_linux" src="https://github.com/user-attachments/assets/0dda3d17-d52f-4717-b434-d744d97131d5" />